### PR TITLE
Add internationalization

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -37,5 +37,9 @@
     "placeholders": {
       "num": { "content": "$1" }
     }
+  },
+
+  "no_downloads": {
+    "message": "There's nothing here..."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,41 @@
+{
+  "header": {
+    "message": "Downloads"
+  },
+
+  "download_again": {
+    "message": "Restart download"
+  },
+
+  "erase_item": {
+    "message": "Remove from list"
+  },
+
+  "show_in": {
+    "message": "Show in $location$",
+    "placeholders": {
+      "location": {
+        "content": "$1",
+        "example": "Finder"
+      }
+    }
+  },
+
+  "location_folder": { "message": "folder" },
+  "location_macos": { "message": "Finder" },
+
+  "show_all": {
+    "message": "Show all downloads",
+    "description": "The message shown for the button that opens chrome://downloads"
+  },
+
+  "prev_page": { "message": "Previous page" },
+  "next_page": { "message": "Next page" },
+
+  "page_number": {
+    "message": "Page $num$",
+    "placeholders": {
+      "num": { "content": "$1" }
+    }
+  }
+}

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -37,5 +37,9 @@
     "placeholders": {
       "num": { "content": "$1" }
     }
+  },
+
+  "no_downloads": {
+    "message": "ダウンロードがない…"
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,0 +1,41 @@
+{
+  "header": {
+    "message": "ダウンロード"
+  },
+
+  "download_again": {
+    "message": "再起動する"
+  },
+
+  "erase_item": {
+    "message": "除く"
+  },
+
+  "show_in": {
+    "message": "$location$で見る",
+    "placeholders": {
+      "location": {
+        "content": "$1",
+        "example": "Finder"
+      }
+    }
+  },
+
+  "location_folder": { "message": "フォルダー" },
+  "location_macos": { "message": "Finder" },
+
+  "show_all": {
+    "message": "すべてを見る",
+    "description": "The message shown for the button that opens chrome://downloads"
+  },
+
+  "prev_page": { "message": "前のページへ" },
+  "next_page": { "message": "次のページへ" },
+
+  "page_number": {
+    "message": "$num$ページ目",
+    "placeholders": {
+      "num": { "content": "$1" }
+    }
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,6 +2,8 @@
   "manifest_version": 3,
   "name": "Download Box",
 
+  "default_locale": "en",
+
   "action": {
     "default_title": "Downloads",
     "default_popup": "popup.html"

--- a/src/popup/Popup.svelte
+++ b/src/popup/Popup.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import { bodyText, search } from 'shared';
+
   import Item from './components/Item.svelte';
 
   // ===== Data =====
-
-  const search = (query: chrome.downloads.DownloadQuery) => {
-    return new Promise<chrome.downloads.DownloadItem[]>(resolve => {
-      chrome.downloads.search(query, resolve);
-    });
-  }
 
   const searchOptions = {
     limit: 5,                   // five per page
@@ -120,7 +116,7 @@
 </script>
 
 <main>
-  <h1>Downloads</h1>
+  <h1>{ bodyText('header') }</h1>
 
   {#if items.length}
     <ul id="download-list">
@@ -129,20 +125,20 @@
       {/each}
     </ul>
   {:else}
-    <div id="empty">There are no downloads in here...</div>
+    <div id="empty">{ bodyText('no_downloads') }</div>
   {/if}
 
   <div id="page-buttons">
-    <button type="button" on:click={prevPage}>Previous page</button>
-    <button type="button" on:click={nextPage}>Next page</button>
-    <div>Page { pageNumber }</div>
+    <button type="button" on:click={prevPage}>{ bodyText('next_page') }</button>
+    <button type="button" on:click={nextPage}>{ bodyText('prev_page') }</button>
+    <div>{ bodyText('page_number', pageNumber) }</div>
   </div>
 
   <div id="show-all">
     <a
       href="chrome://downloads" target="_blank"
       on:click|preventDefault={openDownloads}
-    >Show all downloads</a>
+    >{ bodyText('show_all') }</a>
   </div>
 </main>
 

--- a/src/popup/components/Item.svelte
+++ b/src/popup/components/Item.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { bodyText } from 'shared';
 
   // A blank, 1x1, transparent .gif file to use as a placeholder 'src' attribute
   const emptyGIF = `data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7`;
@@ -75,15 +76,15 @@
       <span class="file-size">{ bytes }</span>
       {#if item.exists}
         <span class="action" role="button" on:click|stopPropagation={show}>
-          Show in { showIn }
+          { bodyText('show_in', showIn) }
         </span>
       {:else if state != 'complete'} <!-- !exists and also not complete -->
         <span class="action" role="button" on:click|stopPropagation={retry}>
-          Restart download
+          { bodyText('download_again') }
         </span>
       {/if}
       <span class="action" role="button" on:click|stopPropagation={erase}>
-        Remove from list
+        { bodyText('erase_item') }
       </span>
     </div>
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -1,4 +1,7 @@
 import Popup from './Popup.svelte';
 import './main.scss';
 
+// @ts-ignore
+window.bodyText = chrome.i18n.getMessage;
+
 export default new Popup({ target: document.body });

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Code used in multiple places all over the extension.
+ */
+
+
+/**
+ * Wrapper for chrome.i18n.getMessage a) for brevity and b) to stop Svelte in VS
+ * Code to stop whining
+ */
+export const bodyText = chrome.i18n.getMessage;
+
+
+/**
+ * Wrapper for chrome.downloads.search that uses a Promise instead of a
+ * callback.
+ * @param query Downloads to search for
+ * @returns The resulting downloads
+ */
+export const search = (query: chrome.downloads.DownloadQuery) => {
+  return new Promise<chrome.downloads.DownloadItem[]>(resolve => {
+    chrome.downloads.search(query, resolve);
+  });
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,7 @@ module.exports = (_, { mode }) => {
       }),
       new CopyWebpackPlugin({
         patterns: [
+          { from: '_locales', to: '_locales' },
           // { from: 'assets', to: 'assets', },
           { from: 'popup/popup.html', to: 'popup.html' },
           {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,9 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const sveltePreprocess = require('svelte-preprocess');
 
 module.exports = (_, { mode }) => {
+  /**
+   * @type {import('webpack').Configuration}
+   */
   const config = {
     context: path.resolve(__dirname, 'src'),
     entry: {
@@ -17,7 +20,8 @@ module.exports = (_, { mode }) => {
     },
     output: {
       path: path.resolve(__dirname, 'dist'),
-      filename: '[name].js'
+      filename: '[name].js',
+      clean: true
     },
     resolve: {
       alias: {


### PR DESCRIPTION
This PR adds a `_locales` folder with `en` and `jp` predefined and starts using `chrome.i18n.getMessage` in the main body of the extension.

I wonder how my French teachers would feel if they knew I was more confident translating to Japanese than I am to French, only 3.5 years after I graduated from French immersion with a DELF certificate... 😅